### PR TITLE
Support multiple tracks in lap in TCX files

### DIFF
--- a/Sources/Classes/Parser/TCX/Extensions/Lap+TCX.swift
+++ b/Sources/Classes/Parser/TCX/Extensions/Lap+TCX.swift
@@ -16,7 +16,7 @@ extension Lap: Tcxable {
 
         // When there are not route points, don't create the instance.
         var routePoints: [Point]? = nil
-        routePoints <~ element["Track"]["Trackpoint"].all?.compactMap { Point(tcx: $0) }
+        routePoints <~ element["Track"].all?.flatMap { $0["Trackpoint"].all?.compactMap { Point(tcx: $0) } ?? [] }
         if routePoints == nil {
             return nil
         }


### PR DESCRIPTION
In TCX files retrieved by [Polar Accesslink API](https://www.polar.com/accesslink-api/#polar-accesslink-api) there are chances that a `Lap` might contain more than one `Track` entries as you can see in the attached image.
![Screenshot 2019-08-23 at 15 44 47](https://user-images.githubusercontent.com/1781500/63593719-31698300-c5bd-11e9-9cef-864ca4af88e7.png)
So I changed the `Lap` initialization to instanciate `points` property from all the `Trackpoint` objects of all the tracks of the lap.